### PR TITLE
Patch/simplify kube auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Deploy a full AWS EKS cluster with Terraform
 8. Worker Nodes in a private Subnet
 9. bastion host for ssh access to the VPC
 10. The ConfigMap required to register Nodes with EKS
-11. KUBECONFIG file to authenticate kubectl using the heptio authenticator aws binary
+11. KUBECONFIG file to authenticate kubectl using the `aws eks get-token` command. needs awscli version `1.16.156 >`
 
 ## Configuration
 
@@ -74,9 +74,9 @@ module "eks" {
   desired-capacity    = "3"
   max-size            = "5"
   min-size            = "1"
-  public-min-size     = "1"
-  public-max-size     = "1"
-  public-desired-capacity = "1"
+  public-min-size     = "0" # setting to 0 will create the launch config etc, but no nodes will deploy"
+  public-max-size     = "0"
+  public-desired-capacity = "0"
   vpc-subnet-cidr     = "10.0.0.0/16"
   private-subnet-cidr = ["10.0.0.0/19", "10.0.32.0/19", "10.0.64.0/19"]
   public-subnet-cidr  = ["10.0.128.0/20", "10.0.144.0/20", "10.0.160.0/20"]

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ module "eks" {
   cluster-name            = var.cluster-name
   k8s-version             = var.k8s-version
   node-instance-type      = var.node-instance-type
+  kublet-extra-args       = var.kublet-extra-args
   root-block-size         = var.root-block-size
   desired-capacity        = var.desired-capacity
   max-size                = var.max-size

--- a/modules/eks/config.tf
+++ b/modules/eks/config.tf
@@ -42,6 +42,8 @@ users:
         - "get-token"
         - "--cluster-name"
         - "${var.cluster-name}"
+        - "--region"
+        - "${var.aws-region}"
 KUBECONFIG
 }
 

--- a/modules/eks/config.tf
+++ b/modules/eks/config.tf
@@ -22,21 +22,21 @@ clusters:
 - cluster:
     server: ${aws_eks_cluster.eks.endpoint}
     certificate-authority-data: ${aws_eks_cluster.eks.certificate_authority.0.data}
-  name: kubernetes
+  name: ${var.cluster-name}
 contexts:
 - context:
-    cluster: kubernetes
-    user: aws
-  name: aws
-current-context: aws
+    cluster: ${var.cluster-name}
+    user: ${var.cluster-name}
+  name: ${var.cluster-name}
+current-context: ${var.cluster-name}
 kind: Config
 preferences: {}
 users:
-- name: aws
+- name: ${var.cluster-name}
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: aws-iam-authenticator
+      command: aws
       args:
         - "token"
         - "-i"

--- a/modules/eks/eks-worker-nodes-public.tf
+++ b/modules/eks/eks-worker-nodes-public.tf
@@ -17,7 +17,7 @@ module "public-eks-nodes-asg" {
   #
   # launch_configuration = "my-existing-launch-configuration" # Use the existing launch configuration
   # create_lc = false # disables creation of launch configuration
-  lc_name = "public-eks-nodes"
+  lc_name = "${var.cluster-name}-node-public-lc"
 
   image_id                     = data.aws_ami.eks-worker-ami.id
   instance_type                = var.node-instance-type
@@ -34,7 +34,7 @@ module "public-eks-nodes-asg" {
   ]
 
   # Auto scaling group
-  asg_name            = "eks-public-nodegroup"
+  asg_name            = "${var.cluster-name}-node-public"
   vpc_zone_identifier = data.aws_subnet_ids.public.ids
 
   health_check_type = "EC2"

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,12 @@ variable "k8s-version" {
   description = "Required K8s version"
 }
 
+variable "kublet-extra-args" {
+  default     = ""
+  type        = string
+  description = "Additional arguments to supply to the node kubelet process"
+}
+
 variable "vpc-subnet-cidr" {
   default     = "10.0.0.0/16"
   type        = string


### PR DESCRIPTION
| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | n/a
| Patch: Bug Fix?          | patch
| Major: Breaking Change?  | no
| Minor: New Feature?      | yes - simpler auth and kublet flags
| Tests Added + Pass?      | Yes
| Any Dependency Changes?  | removes aws-iam-authenticator
| License                  | MIT

Uses `aws eks get-token` to simplify cluster auth and remove dependancy on aws-iam-authenticator
Adds `kublet-extra-args` to a nodes